### PR TITLE
Использовать объект вместо функции для фраз

### DIFF
--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -2,6 +2,12 @@ import lodash from 'lodash'
 import format from 'string-template'
 import { GREEN_MARK, RED_CROSS, WHITE_QUESTION_MARK } from '../const/emojies'
 
+/**
+ * @deprecated use phrase.some.path(...data)
+ * @param key
+ * @param data
+ * @private
+ */
 export function __(key: string, data?: { [key: string]: string }) {
     const source = lodash.get(strings, key, '')
 
@@ -11,7 +17,6 @@ export function __(key: string, data?: { [key: string]: string }) {
 
     return format(source || key, data)
 }
-
 
 type InstrumentedStringTree<T> = {
     [P in keyof T]: T[P] extends string ? (values?: { [key: string]: string }) => string : InstrumentedStringTree<T[P]>

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -18,8 +18,9 @@ export function __(key: string, data?: { [key: string]: string }) {
     return format(source || key, data)
 }
 
+type TemplateProcessor = (values?: { [key: string]: string }) => string
 type InstrumentedStringTree<T> = {
-    [P in keyof T]: T[P] extends string ? (values?: { [key: string]: string }) => string : InstrumentedStringTree<T[P]>
+    [P in keyof T]: T[P] extends string ? TemplateProcessor : InstrumentedStringTree<T[P]>
 }
 
 type StringTree = {


### PR DESCRIPTION
Раньше для того, чтобы получить фразу для ответа надо было делать так:
```javascript
import { __ } from '../.../strings.ts'

__('some.path.to.phrase', { opt: val })
```

Теперь функция `__` помечается как deprecated и вместо неё предлагается использовать следующий синтаксис:
```javascript
import phrases from '../.../strings.ts'

phrases.some.path.to.phrase({ opt: val })
```